### PR TITLE
Fix Large Array Handling in `estimate_place_fields` Function

### DIFF
--- a/replay_trajectory_classification/likelihoods/spiking_likelihood_glm.py
+++ b/replay_trajectory_classification/likelihoods/spiking_likelihood_glm.py
@@ -234,7 +234,8 @@ def estimate_place_fields(
     except ValueError:
         client = Client()
     design_matrix = client.scatter(np.asarray(design_matrix), broadcast=True)
-    results = [fit_glm(is_spike, design_matrix, penalty) for is_spike in spikes.T]
+    scattered_spikes = [client.scatter(is_spike) for is_spike in spikes.T]
+    results = [fit_glm(is_spike, design_matrix, penalty) for is_spike in scattered_spikes]
     results = dask.compute(*results)
 
     predict_matrix = make_spline_predict_matrix(design_info, place_bin_centers)


### PR DESCRIPTION
This PR fixes the issue described in #36 by calling `client.scatter` on the spikes array before passing it to the dask compute cluster. This approach distributes the large array across the cluster, as opposed to passing it all at once, preventing the ValueError.